### PR TITLE
Fix unintended deleting of non-code comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,18 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.walkmod</groupId>
+			<artifactId>walkmod-javalang-plugin</artifactId>
+			<version>[2.0, 3.0)</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<profiles>
 		<profile>

--- a/src/main/java/org/walkmod/commentscleaner/visitors/CommentsCleanerVisitor.java
+++ b/src/main/java/org/walkmod/commentscleaner/visitors/CommentsCleanerVisitor.java
@@ -6,6 +6,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Stack;
 
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggerFactory;
 import org.walkmod.javalang.ASTManager;
 import org.walkmod.javalang.ParseException;
 import org.walkmod.javalang.ast.BlockComment;
@@ -15,19 +17,18 @@ import org.walkmod.javalang.ast.LineComment;
 import org.walkmod.javalang.visitors.VoidVisitorAdapter;
 
 public class CommentsCleanerVisitor<T> extends VoidVisitorAdapter<T> {
+   private static final Logger log = Logger.getLogger(CommentsCleanerVisitor.class);
 
    @Override
    public void visit(CompilationUnit cu, T ctx) {
       List<Comment> comments = cu.getComments();
       if (comments != null) {
          List<Comment> finalComments = new LinkedList<Comment>();
-         Iterator<Comment> it = comments.iterator();
 
          Stack<List<Comment>> toogleComments = new Stack<List<Comment>>();
 
          Comment lastLineComment = null;
-         while (it.hasNext()) {
-            Comment comment = it.next();
+         for (Comment comment : comments) {
             if (comment instanceof BlockComment) {
                if (!requiresToDelete(comment.getContent())) {
                   finalComments.add(comment);
@@ -46,25 +47,18 @@ public class CommentsCleanerVisitor<T> extends VoidVisitorAdapter<T> {
                }
                lastLineComment = comment;
             } else {
-
                finalComments.add(comment);
             }
          }
-         Iterator<List<Comment>> itToogle = toogleComments.iterator();
-         while (itToogle.hasNext()) {
-            List<Comment> toogle = itToogle.next();
-            String content = "";
-            for (Comment c : toogle) {
-               content +=  c.getContent();
-            }
-            if (!requiresToDelete(content)) {
+
+         for (List<Comment> toogle : toogleComments) {
+            if (!requiresToDelete(toogle)) {
                if (!finalComments.isEmpty()) {
+                  // merge toogle into finalComments according to their position
                   Comment firstComment = toogle.get(0);
-                  Iterator<Comment> fcIt = finalComments.iterator();
                   boolean added = false;
                   List<Comment> accum = new LinkedList<Comment>();
-                  while (fcIt.hasNext()) {
-                     Comment addedComment = fcIt.next();
+                  for (Comment addedComment : finalComments) {
                      if (addedComment.isPreviousThan(firstComment)) {
                         accum.add(addedComment);
                      } else {
@@ -75,9 +69,11 @@ public class CommentsCleanerVisitor<T> extends VoidVisitorAdapter<T> {
                         accum.add(addedComment);
                      }
                   }
+                  if (!added) {
+                     accum.addAll(toogle);
+                  }
                   finalComments = accum;
-               }
-               else{
+               } else{
                   finalComments = toogle;
                }
             }
@@ -88,12 +84,21 @@ public class CommentsCleanerVisitor<T> extends VoidVisitorAdapter<T> {
       }
    }
 
+   private boolean requiresToDelete(List<Comment> comments) {
+      String code = "";
+      for (Comment c : comments) {
+         code +=  c.getContent();
+      }
+      return requiresToDelete(code);
+   }
+
    private boolean requiresToDelete(String code) {
       try {
          if(!code.startsWith("{")){
             code = "{"+code+"}";
          }
          ASTManager.parse(Statement.class, code);
+         log.debug("Deleting " + code);
          return true;
       } catch (ParseException e) {
       }

--- a/src/test/java/org/walkmod/commentscleaner/visitors/CommentsCleanerVisitorTest.java
+++ b/src/test/java/org/walkmod/commentscleaner/visitors/CommentsCleanerVisitorTest.java
@@ -1,10 +1,21 @@
 package org.walkmod.commentscleaner.visitors;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.walkmod.javalang.ASTManager;
 import org.walkmod.javalang.ParseException;
+import org.walkmod.javalang.actions.Action;
+import org.walkmod.javalang.actions.ActionsApplier;
 import org.walkmod.javalang.ast.CompilationUnit;
+import org.walkmod.javalang.walkers.ChangeLogVisitor;
+import org.walkmod.walkers.VisitorContext;
 
 
 public class CommentsCleanerVisitorTest {
@@ -14,7 +25,7 @@ public class CommentsCleanerVisitorTest {
       CompilationUnit cu = ASTManager.parse("public class Foo { /*for (int i = 0; i < value; i++) {\nmultiply(value);\n}*/}");
       CommentsCleanerVisitor<?> visitor = new CommentsCleanerVisitor<Object>();
       cu.accept(visitor, null);
-      Assert.assertEquals(0, cu.getComments().size());
+      assertEquals(0, cu.getComments().size());
    }
    
    @Test
@@ -22,7 +33,7 @@ public class CommentsCleanerVisitorTest {
       CompilationUnit cu = ASTManager.parse("public class Foo { //TODO: Important!\n /*int a = 1;*/}");
       CommentsCleanerVisitor<?> visitor = new CommentsCleanerVisitor<Object>();
       cu.accept(visitor, null);
-      Assert.assertEquals(1, cu.getComments().size());
+      assertEquals(1, cu.getComments().size());
    }
    
    @Test
@@ -30,7 +41,29 @@ public class CommentsCleanerVisitorTest {
       CompilationUnit cu = ASTManager.parse("public class Foo { \n//for (int i = 0; i < value; i++) {\n//multiply(value);\n//}\n }");
       CommentsCleanerVisitor<?> visitor = new CommentsCleanerVisitor<Object>();
       cu.accept(visitor, null);
-      Assert.assertEquals(0, cu.getComments().size());
+      assertEquals(0, cu.getComments().size());
    }
+
+
+    @Test
+    public void testLastCommentIsLineComment() throws Exception {
+        String code = IOUtils.toString(new File("src/test/resources/Test1.txt").toURI());
+        CompilationUnit cu = ASTManager.parse(code);
+
+        CommentsCleanerVisitor<?> commentsCleanerVisitor = new CommentsCleanerVisitor<Object>();
+        cu.accept(commentsCleanerVisitor, null);
+
+        ChangeLogVisitor changeLogVisitor = new ChangeLogVisitor();
+        VisitorContext ctx = new VisitorContext();
+        ctx.put(ChangeLogVisitor.NODE_TO_COMPARE_KEY, ASTManager.parse(code));
+        changeLogVisitor.visit(cu, ctx);
+        List<Action> actions = changeLogVisitor.getActionsToApply();
+        ActionsApplier applier = new ActionsApplier();
+        applier.setActionList(actions);
+        applier.setText(code);
+        applier.execute();
+        String result = applier.getModifiedText();
+        assertEquals(code, result);
+    }
    
 }

--- a/src/test/resources/Test1.txt
+++ b/src/test/resources/Test1.txt
@@ -1,0 +1,10 @@
+/**
+ */
+private class Foo {
+
+    public void bar() {
+        int i;
+        // comment
+    }
+}
+

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=DEBUG,stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+


### PR DESCRIPTION
If source file contains block or javascript comments followed
by one or more line comments in a group, not followed by any
other block or javadoc comments, this line comment group
was silently discarded. Fixed in CommentsCleanerVisitor#visit .
